### PR TITLE
Remove extra 'n' class in post author

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -85,7 +85,7 @@ function _strapter_posted_on() {
 
 	$byline = sprintf(
 		_x( 'by %s', 'post author', '_strapter' ),
-		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+		'<span class="author vcard"><a class="url fn" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
 	);
 
 	echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>';


### PR DESCRIPTION
Removing extra 'n' class at _strapter_posted_on.
better preview this case at https://developers.google.com/structured-data/testing-tool/